### PR TITLE
add additional common plugins, update readme, add

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 80,
+  "semi": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2018
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # babel-preset-mobx
 
-> Babel preset for all Mobx plugins.
+> Babel preset for ES features commonly used with [mobx](https://mobx.js.org/)
+
+This preset includes the following plugins:
+
+* `transform-decorators-legacy`
+* `transform-class-properties`
+* `transform-es2015-classes`
+* `transform-regenerator`
+
+In order to use async/generator functions, you will need to add
+[`babel-polyfill`](https://babeljs.io/docs/usage/polyfill/) or
+[`regenerator-runtime`](https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime)
+to your `dependencies` (note: that's not `devDependencies`, as it's needed at
+runtime).
 
 ## Install
 
@@ -23,7 +36,7 @@ $ npm install --save-dev babel-preset-mobx
 ### Via CLI
 
 ```sh
-$ babel script.js --presets mobx 
+$ babel script.js --presets mobx
 ```
 
 ### Via Node API

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "repository": "https://github.com/zwhitchcox/babel-preset-mobx",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-plugin-transform-decorators-legacy": "^1.3.4"
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-es2015-classes": "^6.24.1",
+    "babel-plugin-transform-regenerator": "^6.26.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,10 @@
-module.exports = {
-  plugins: [
-    transformLegacyDecorators: require('babel-plugin-transform-legacy-decorators')
-  ],
+module.exports = function() {
+    return {
+        plugins: [
+            'transform-decorators-legacy',
+            'transform-class-properties',
+            'transform-es2015-classes',
+            ['transform-regenerator', { asyncGenerators: false }],
+        ],
+    };
 };


### PR DESCRIPTION
I was going to build a plugin like this myself in response to mobxjs/mobx#1331, but I found this repo and figured why not contribute to it instead of reinventing the wheel?

I've added a few more transforms (as noted in Michael's list) as well as some updates to the README to reflect those additional dependencies. 

I also was having problems with the object export that were resolved by changing it to a function that returns an object instead. Also added a `.prettierrc` and a `.gitignore` as well.