### PR TITLE
Update dependencies for Babel 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 module.exports = function() {
     return {
         plugins: [
-            'transform-decorators-legacy',
-            'transform-class-properties',
-            'transform-es2015-classes',
-            ['transform-regenerator', { asyncGenerators: false }],
+            ['@babel/plugin-proposal-decorators', { legacy: true }],
+            '@babel/plugin-proposal-class-properties',
+            '@babel/plugin-transform-classes',
+            ['@babel/plugin-transform-regenerator', { asyncGenerators: false }],
         ],
     };
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = function() {
     return {
         plugins: [
             ['@babel/plugin-proposal-decorators', { legacy: true }],
-            '@babel/plugin-proposal-class-properties',
+            ['@babel/plugin-proposal-class-properties', { loose: true }],
             '@babel/plugin-transform-classes',
             ['@babel/plugin-transform-regenerator', { asyncGenerators: false }],
         ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-mobx",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Babel preset for all Mobx plugins.",
   "author": "Zane Hitchcox <zwhitchcox@gmail.com>",
   "homepage": "https://babeljs.io/",
@@ -8,9 +8,9 @@
   "repository": "https://github.com/zwhitchcox/babel-preset-mobx",
   "main": "index.js",
   "dependencies": {
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-es2015-classes": "^6.24.1",
-    "babel-plugin-transform-regenerator": "^6.26.0"
+    "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/plugin-proposal-decorators": "^7.0.0",
+    "@babel/plugin-transform-classes": "^7.0.0",
+    "@babel/plugin-transform-regenerator": "^7.0.0"
   }
 }


### PR DESCRIPTION
Hi,

Creating this PR to update the dependencies for Babel 7, following the guidelines in the [Upgrade to Babel 7](https://babeljs.io/docs/en/next/v7-migration) article.

As the change in Babel version is a major one, I also bumped the version to `2.0.0` to prevent people already using this package with Babel 6 from getting this update with `npm update`.